### PR TITLE
feat: implement theme system for fusabi-tui-runtime (Issue #6)

### DIFF
--- a/THEME_SYSTEM.md
+++ b/THEME_SYSTEM.md
@@ -1,0 +1,250 @@
+# Theme System
+
+The fusabi-tui-runtime now includes a comprehensive theme system that allows for consistent styling across all TUI widgets and components.
+
+## Overview
+
+The theme system consists of three main components:
+
+- **ColorPalette** - Defines the base color palette (background, foreground, primary, secondary, accent, error, warning, success)
+- **StyleMap** - Maps semantic names to specific styles for different UI elements
+- **Theme** - Combines palette and styles with metadata into a complete theme
+
+## Features
+
+- **Built-in Themes**: Dark, Light, and Slime (matching Scarab terminal)
+- **Custom Themes**: Create your own themes programmatically or via TOML files
+- **TOML Support**: Load and save themes from/to TOML configuration files (requires `serde` feature)
+- **Widget Integration**: Widgets can apply theme styles with the `.themed()` method
+- **Runtime Switching**: Change themes at runtime without rebuilding
+
+## Usage
+
+### Using Built-in Themes
+
+```rust
+use fusabi_tui_core::theme::Theme;
+
+// Create a dark theme
+let dark = Theme::dark();
+
+// Create a light theme
+let light = Theme::light();
+
+// Create the Slime theme (from Scarab terminal)
+let slime = Theme::slime();
+```
+
+### Creating Custom Themes
+
+```rust
+use fusabi_tui_core::theme::{Theme, ColorPalette};
+use fusabi_tui_core::style::Color;
+
+let palette = ColorPalette {
+    background: Color::Black,
+    foreground: Color::White,
+    primary: Color::Blue,
+    secondary: Color::Cyan,
+    accent: Color::Green,
+    error: Color::Red,
+    warning: Color::Yellow,
+    success: Color::Green,
+};
+
+let theme = Theme::new("My Theme", palette);
+```
+
+### Applying Themes to Widgets
+
+```rust
+use fusabi_tui_core::theme::Theme;
+use fusabi_tui_widgets::block::Block;
+use fusabi_tui_widgets::borders::Borders;
+
+let theme = Theme::dark();
+
+let block = Block::default()
+    .title("Themed Panel")
+    .borders(Borders::ALL)
+    .themed(&theme);  // Apply theme styles
+```
+
+### Getting Specific Styles
+
+```rust
+let theme = Theme::dark();
+
+// Get predefined styles
+let title_style = theme.get_style("title");
+let border_style = theme.get_style("border");
+let error_style = theme.error_style();
+let success_style = theme.success_style();
+
+// Get base style
+let base = theme.base_style();
+```
+
+### Loading Themes from TOML
+
+Enable the `serde` feature in your `Cargo.toml`:
+
+```toml
+[dependencies]
+fusabi-tui-core = { version = "0.1", features = ["serde"] }
+```
+
+Then load a theme:
+
+```rust
+use fusabi_tui_core::theme::Theme;
+
+// From a TOML string
+let toml_str = r#"
+    name = "My Theme"
+
+    [colors]
+    background = "Black"
+    foreground = "White"
+    primary = "Blue"
+    secondary = "Cyan"
+    accent = "Magenta"
+    error = "Red"
+    warning = "Yellow"
+    success = "Green"
+"#;
+
+let theme = Theme::from_toml(toml_str).unwrap();
+
+// From a TOML file
+let theme = Theme::from_toml_file("theme.toml").unwrap();
+```
+
+### Saving Themes to TOML
+
+```rust
+let theme = Theme::slime();
+
+// Save to string
+let toml_str = theme.to_toml().unwrap();
+println!("{}", toml_str);
+
+// Save to file
+theme.to_toml_file("slime.toml").unwrap();
+```
+
+## Built-in Theme Details
+
+### Dark Theme
+
+A dark theme with subtle colors suitable for low-light environments:
+
+- Background: Black
+- Foreground: White
+- Primary: Blue
+- Secondary: Cyan
+- Accent: Magenta
+
+### Light Theme
+
+A light theme suitable for bright environments:
+
+- Background: White
+- Foreground: Black
+- Primary: Blue
+- Secondary: Cyan
+- Accent: Magenta
+
+### Slime Theme
+
+The Slime theme from Scarab terminal emulator with green/cyan accents:
+
+- Background: `#1e2324` (dark gray-green)
+- Foreground: `#e0e0e0` (light gray)
+- Primary: `#a8df5a` (slime green)
+- Secondary: `#80B5B3` (cyan)
+- Accent: `#AEC199` (muted green)
+- Error: `#cd6564` (red)
+- Warning: `#fff099` (yellow)
+- Success: `#AEC199` (green)
+
+## Available Style Names
+
+The following style names are available via `theme.get_style()`:
+
+### Basic Styles
+- `base` - Base style with foreground on background
+- `title` - Title text style
+- `border` - Border style
+- `text` - Regular text style
+
+### Interactive Element Styles
+- `selected` - Selected item style
+- `highlight` - Highlighted text style
+- `focus` - Focused element style
+
+### Status Styles
+- `error` - Error message style
+- `warning` - Warning message style
+- `success` - Success message style
+
+### Widget-Specific Styles
+- `gauge_bar` - Gauge/progress bar style
+- `gauge_label` - Gauge label style
+- `table_header` - Table header style
+- `table_selected` - Selected table row style
+- `list_selected` - Selected list item style
+- `tab_active` - Active tab style
+- `tab_inactive` - Inactive tab style
+
+## Examples
+
+Run the theme demo:
+
+```bash
+cargo run -p fusabi-tui-widgets --example theme_demo
+```
+
+With serde support:
+
+```bash
+cargo run -p fusabi-tui-widgets --features fusabi-tui-core/serde --example theme_demo
+```
+
+## Color Format
+
+Colors can be specified in several formats:
+
+- **Named colors**: `"Black"`, `"Red"`, `"Green"`, `"Yellow"`, `"Blue"`, `"Magenta"`, `"Cyan"`, `"White"`, `"DarkGray"`, `"LightRed"`, etc.
+- **RGB**: `{ Rgb = [255, 128, 0] }`
+- **Indexed**: `{ Indexed = 42 }`
+- **Reset**: `"Reset"`
+
+When using TOML, use the string format for named colors.
+
+## Architecture
+
+The theme system is implemented in `fusabi-tui-core` and is available to all widgets in `fusabi-tui-widgets`. The `serde` feature is optional and adds TOML serialization/deserialization support.
+
+```
+fusabi-tui-core
+└── theme module
+    ├── ColorPalette
+    ├── StyleMap (HashMap<String, Style>)
+    └── Theme
+        ├── Built-in themes (dark, light, slime)
+        ├── TOML loading/saving (with serde feature)
+        └── Style helpers
+```
+
+## Future Enhancements
+
+Potential future improvements to the theme system:
+
+1. Hot-reloading themes from files
+2. Theme inheritance (extend existing themes)
+3. Per-widget theme overrides
+4. Theme validation
+5. Theme preview/generation tools
+6. Additional built-in themes
+7. Theme color interpolation for animations

--- a/crates/fusabi-tui-core/Cargo.toml
+++ b/crates/fusabi-tui-core/Cargo.toml
@@ -12,3 +12,9 @@ categories = ["command-line-interface", "gui", "rendering"]
 
 [dependencies]
 unicode-width = "0.1"
+serde = { version = "1.0", features = ["derive"], optional = true }
+toml = { version = "0.8", optional = true }
+
+[features]
+default = []
+serde = ["dep:serde", "dep:toml"]

--- a/crates/fusabi-tui-core/src/lib.rs
+++ b/crates/fusabi-tui-core/src/lib.rs
@@ -70,8 +70,10 @@ pub mod buffer;
 pub mod layout;
 pub mod style;
 pub mod symbols;
+pub mod theme;
 
 // Re-export commonly used types at the crate root for convenience
 pub use buffer::{Buffer, Cell};
 pub use layout::{Constraint, Direction, Layout, Rect};
 pub use style::{Color, Modifier, Style};
+pub use theme::{ColorPalette, StyleMap, Theme};

--- a/crates/fusabi-tui-core/src/style.rs
+++ b/crates/fusabi-tui-core/src/style.rs
@@ -5,10 +5,14 @@
 
 use std::fmt;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
 /// Represents a color in the terminal.
 ///
 /// Supports both standard ANSI colors and extended 256-color/RGB modes.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub enum Color {
     /// Black color (ANSI 0)
     Black,
@@ -86,6 +90,7 @@ impl fmt::Display for Color {
 ///
 /// These can be combined using bitwise operations.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Modifier(u16);
 
 impl Modifier {
@@ -214,6 +219,7 @@ impl std::ops::Not for Modifier {
 ///     .add_modifier(Modifier::BOLD);
 /// ```
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 pub struct Style {
     /// Foreground color
     pub fg: Option<Color>,

--- a/crates/fusabi-tui-core/src/theme.rs
+++ b/crates/fusabi-tui-core/src/theme.rs
@@ -1,0 +1,562 @@
+//! Theme system for styling TUI applications.
+//!
+//! This module provides a comprehensive theming system that allows for consistent
+//! styling across all TUI widgets and components. Themes define color palettes,
+//! semantic color mappings, and can be loaded from TOML configuration files.
+//!
+//! # Overview
+//!
+//! The theme system consists of three main components:
+//!
+//! - [`ColorPalette`] - Defines the base color palette (background, foreground, accents, etc.)
+//! - [`StyleMap`] - Maps semantic names to specific styles for different UI elements
+//! - [`Theme`] - Combines palette and styles with metadata into a complete theme
+//!
+//! # Examples
+//!
+//! ```rust
+//! use fusabi_tui_core::theme::{Theme, ColorPalette, StyleMap};
+//! use fusabi_tui_core::style::{Color, Style};
+//!
+//! // Create a custom theme
+//! let palette = ColorPalette {
+//!     background: Color::Black,
+//!     foreground: Color::White,
+//!     primary: Color::Blue,
+//!     secondary: Color::Cyan,
+//!     accent: Color::Green,
+//!     error: Color::Red,
+//!     warning: Color::Yellow,
+//!     success: Color::Green,
+//! };
+//!
+//! let mut styles = StyleMap::new();
+//! styles.insert("title".to_string(), Style::new().fg(Color::Blue));
+//!
+//! let theme = Theme {
+//!     name: "My Theme".to_string(),
+//!     colors: palette,
+//!     styles,
+//! };
+//! ```
+//!
+//! # Built-in Themes
+//!
+//! The module provides several built-in themes:
+//!
+//! - [`Theme::dark()`] - A dark theme with subtle colors
+//! - [`Theme::light()`] - A light theme suitable for bright environments
+//! - [`Theme::slime()`] - The Slime theme from Scarab terminal with green accents
+
+use crate::style::{Color, Style};
+use std::collections::HashMap;
+
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+/// A color palette defining the base colors for a theme.
+///
+/// This struct contains all the fundamental colors used throughout the UI.
+/// Individual widgets can reference these colors to maintain consistency.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct ColorPalette {
+    /// Default background color
+    pub background: Color,
+    /// Default foreground (text) color
+    pub foreground: Color,
+    /// Primary accent color (used for interactive elements)
+    pub primary: Color,
+    /// Secondary accent color (used for highlights)
+    pub secondary: Color,
+    /// Accent color (used for emphasis)
+    pub accent: Color,
+    /// Error state color
+    pub error: Color,
+    /// Warning state color
+    pub warning: Color,
+    /// Success state color
+    pub success: Color,
+}
+
+impl Default for ColorPalette {
+    fn default() -> Self {
+        Self::dark()
+    }
+}
+
+impl ColorPalette {
+    /// Creates a dark color palette.
+    pub fn dark() -> Self {
+        Self {
+            background: Color::Black,
+            foreground: Color::White,
+            primary: Color::Blue,
+            secondary: Color::Cyan,
+            accent: Color::Magenta,
+            error: Color::Red,
+            warning: Color::Yellow,
+            success: Color::Green,
+        }
+    }
+
+    /// Creates a light color palette.
+    pub fn light() -> Self {
+        Self {
+            background: Color::White,
+            foreground: Color::Black,
+            primary: Color::Blue,
+            secondary: Color::Cyan,
+            accent: Color::Magenta,
+            error: Color::Red,
+            warning: Color::Yellow,
+            success: Color::Green,
+        }
+    }
+
+    /// Creates the Slime theme color palette.
+    ///
+    /// Based on the Slime theme from Scarab terminal emulator.
+    /// Features a dark background with green/cyan accents.
+    pub fn slime() -> Self {
+        Self {
+            background: Color::Rgb(30, 35, 36),        // #1e2324
+            foreground: Color::Rgb(224, 224, 224),     // #e0e0e0
+            primary: Color::Rgb(168, 223, 90),         // #a8df5a (slime green)
+            secondary: Color::Rgb(128, 181, 179),      // #80B5B3 (cyan)
+            accent: Color::Rgb(174, 193, 153),         // #AEC199 (green)
+            error: Color::Rgb(205, 101, 100),          // #cd6564 (red)
+            warning: Color::Rgb(255, 240, 153),        // #fff099 (yellow)
+            success: Color::Rgb(174, 193, 153),        // #AEC199 (green)
+        }
+    }
+}
+
+/// A map of semantic style names to actual styles.
+///
+/// This allows widgets to reference styles by name (e.g., "title", "border", "selected")
+/// without hardcoding specific colors. The theme can override these mappings.
+pub type StyleMap = HashMap<String, Style>;
+
+/// A complete theme combining colors, styles, and metadata.
+///
+/// Themes provide a consistent look and feel across the entire application.
+/// They can be created programmatically or loaded from configuration files.
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+pub struct Theme {
+    /// Theme name
+    pub name: String,
+    /// Color palette
+    pub colors: ColorPalette,
+    /// Named style mappings
+    #[cfg_attr(feature = "serde", serde(default, skip_serializing_if = "StyleMap::is_empty"))]
+    pub styles: StyleMap,
+}
+
+impl Default for Theme {
+    fn default() -> Self {
+        Self::dark()
+    }
+}
+
+impl Theme {
+    /// Creates a new theme with the given name and color palette.
+    ///
+    /// Default styles will be generated based on the color palette.
+    pub fn new(name: impl Into<String>, colors: ColorPalette) -> Self {
+        let name = name.into();
+        let styles = Self::default_styles(&colors);
+        Self {
+            name,
+            colors,
+            styles,
+        }
+    }
+
+    /// Creates the default dark theme.
+    pub fn dark() -> Self {
+        Self::new("Dark", ColorPalette::dark())
+    }
+
+    /// Creates a light theme.
+    pub fn light() -> Self {
+        Self::new("Light", ColorPalette::light())
+    }
+
+    /// Creates the Slime theme.
+    ///
+    /// Based on the Slime theme from Scarab terminal emulator.
+    /// Features a dark background with green/cyan accents.
+    pub fn slime() -> Self {
+        Self::new("Slime", ColorPalette::slime())
+    }
+
+    /// Gets a style by name, falling back to default if not found.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use fusabi_tui_core::theme::Theme;
+    ///
+    /// let theme = Theme::dark();
+    /// let title_style = theme.get_style("title");
+    /// let border_style = theme.get_style("border");
+    /// ```
+    pub fn get_style(&self, name: &str) -> Style {
+        self.styles
+            .get(name)
+            .copied()
+            .unwrap_or_else(|| Style::new().fg(self.colors.foreground))
+    }
+
+    /// Sets a style by name.
+    pub fn set_style(&mut self, name: impl Into<String>, style: Style) {
+        self.styles.insert(name.into(), style);
+    }
+
+    /// Gets the base style (foreground on background).
+    pub fn base_style(&self) -> Style {
+        Style::new()
+            .fg(self.colors.foreground)
+            .bg(self.colors.background)
+    }
+
+    /// Gets the primary style.
+    pub fn primary_style(&self) -> Style {
+        Style::new().fg(self.colors.primary)
+    }
+
+    /// Gets the secondary style.
+    pub fn secondary_style(&self) -> Style {
+        Style::new().fg(self.colors.secondary)
+    }
+
+    /// Gets the accent style.
+    pub fn accent_style(&self) -> Style {
+        Style::new().fg(self.colors.accent)
+    }
+
+    /// Gets the error style.
+    pub fn error_style(&self) -> Style {
+        Style::new().fg(self.colors.error)
+    }
+
+    /// Gets the warning style.
+    pub fn warning_style(&self) -> Style {
+        Style::new().fg(self.colors.warning)
+    }
+
+    /// Gets the success style.
+    pub fn success_style(&self) -> Style {
+        Style::new().fg(self.colors.success)
+    }
+
+    /// Loads a theme from a TOML string.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the TOML is invalid or cannot be deserialized.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use fusabi_tui_core::theme::Theme;
+    ///
+    /// let toml_str = r#"
+    ///     name = "My Theme"
+    ///
+    ///     [colors]
+    ///     background = "Black"
+    ///     foreground = "White"
+    ///     primary = "Blue"
+    ///     secondary = "Cyan"
+    ///     accent = "Magenta"
+    ///     error = "Red"
+    ///     warning = "Yellow"
+    ///     success = "Green"
+    /// "#;
+    ///
+    /// let theme = Theme::from_toml(toml_str).unwrap();
+    /// ```
+    #[cfg(feature = "serde")]
+    pub fn from_toml(toml_str: &str) -> Result<Self, String> {
+        let mut theme: Self = toml::from_str(toml_str)
+            .map_err(|e| format!("Failed to parse TOML: {}", e))?;
+
+        // Generate default styles if none were provided
+        if theme.styles.is_empty() {
+            theme.styles = Self::default_styles(&theme.colors);
+        }
+
+        Ok(theme)
+    }
+
+    /// Loads a theme from a TOML file.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the file cannot be read or parsed.
+    #[cfg(feature = "serde")]
+    pub fn from_toml_file(path: impl AsRef<std::path::Path>) -> Result<Self, String> {
+        let content = std::fs::read_to_string(path)
+            .map_err(|e| format!("Failed to read theme file: {}", e))?;
+        Self::from_toml(&content)
+    }
+
+    /// Saves a theme to a TOML string.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the theme cannot be serialized.
+    #[cfg(feature = "serde")]
+    pub fn to_toml(&self) -> Result<String, String> {
+        toml::to_string_pretty(self).map_err(|e| format!("Failed to serialize theme: {}", e))
+    }
+
+    /// Saves a theme to a TOML file.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the file cannot be written.
+    #[cfg(feature = "serde")]
+    pub fn to_toml_file(&self, path: impl AsRef<std::path::Path>) -> Result<(), String> {
+        let content = self.to_toml()?;
+        std::fs::write(path, content)
+            .map_err(|e| format!("Failed to write theme file: {}", e))
+    }
+
+    /// Generates default styles based on the color palette.
+    fn default_styles(colors: &ColorPalette) -> StyleMap {
+        let mut styles = HashMap::new();
+
+        // Basic styles
+        styles.insert(
+            "base".to_string(),
+            Style::new().fg(colors.foreground).bg(colors.background),
+        );
+        styles.insert("title".to_string(), Style::new().fg(colors.primary));
+        styles.insert("border".to_string(), Style::new().fg(colors.secondary));
+        styles.insert("text".to_string(), Style::new().fg(colors.foreground));
+
+        // Interactive element styles
+        styles.insert(
+            "selected".to_string(),
+            Style::new().fg(colors.background).bg(colors.primary),
+        );
+        styles.insert(
+            "highlight".to_string(),
+            Style::new().fg(colors.accent),
+        );
+        styles.insert(
+            "focus".to_string(),
+            Style::new().fg(colors.primary),
+        );
+
+        // Status styles
+        styles.insert("error".to_string(), Style::new().fg(colors.error));
+        styles.insert("warning".to_string(), Style::new().fg(colors.warning));
+        styles.insert("success".to_string(), Style::new().fg(colors.success));
+
+        // Widget-specific styles
+        styles.insert(
+            "gauge_bar".to_string(),
+            Style::new().fg(colors.primary).bg(colors.background),
+        );
+        styles.insert(
+            "gauge_label".to_string(),
+            Style::new().fg(colors.foreground),
+        );
+        styles.insert(
+            "table_header".to_string(),
+            Style::new().fg(colors.primary),
+        );
+        styles.insert(
+            "table_selected".to_string(),
+            Style::new().fg(colors.background).bg(colors.primary),
+        );
+        styles.insert(
+            "list_selected".to_string(),
+            Style::new().fg(colors.background).bg(colors.primary),
+        );
+        styles.insert(
+            "tab_active".to_string(),
+            Style::new().fg(colors.background).bg(colors.primary),
+        );
+        styles.insert(
+            "tab_inactive".to_string(),
+            Style::new().fg(colors.foreground),
+        );
+
+        styles
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_color_palette_dark() {
+        let palette = ColorPalette::dark();
+        assert_eq!(palette.background, Color::Black);
+        assert_eq!(palette.foreground, Color::White);
+        assert_eq!(palette.primary, Color::Blue);
+    }
+
+    #[test]
+    fn test_color_palette_light() {
+        let palette = ColorPalette::light();
+        assert_eq!(palette.background, Color::White);
+        assert_eq!(palette.foreground, Color::Black);
+    }
+
+    #[test]
+    fn test_color_palette_slime() {
+        let palette = ColorPalette::slime();
+        assert_eq!(palette.background, Color::Rgb(30, 35, 36));
+        assert_eq!(palette.foreground, Color::Rgb(224, 224, 224));
+        assert_eq!(palette.primary, Color::Rgb(168, 223, 90));
+    }
+
+    #[test]
+    fn test_theme_dark() {
+        let theme = Theme::dark();
+        assert_eq!(theme.name, "Dark");
+        assert_eq!(theme.colors.background, Color::Black);
+    }
+
+    #[test]
+    fn test_theme_light() {
+        let theme = Theme::light();
+        assert_eq!(theme.name, "Light");
+        assert_eq!(theme.colors.background, Color::White);
+    }
+
+    #[test]
+    fn test_theme_slime() {
+        let theme = Theme::slime();
+        assert_eq!(theme.name, "Slime");
+        assert_eq!(theme.colors.background, Color::Rgb(30, 35, 36));
+    }
+
+    #[test]
+    fn test_theme_get_style() {
+        let theme = Theme::dark();
+        let title_style = theme.get_style("title");
+        assert_eq!(title_style.fg, Some(Color::Blue));
+
+        // Test fallback for non-existent style
+        let unknown_style = theme.get_style("unknown");
+        assert_eq!(unknown_style.fg, Some(Color::White));
+    }
+
+    #[test]
+    fn test_theme_set_style() {
+        let mut theme = Theme::dark();
+        let custom_style = Style::new().fg(Color::Red);
+        theme.set_style("custom", custom_style);
+
+        let retrieved_style = theme.get_style("custom");
+        assert_eq!(retrieved_style.fg, Some(Color::Red));
+    }
+
+    #[test]
+    fn test_theme_base_style() {
+        let theme = Theme::dark();
+        let base = theme.base_style();
+        assert_eq!(base.fg, Some(Color::White));
+        assert_eq!(base.bg, Some(Color::Black));
+    }
+
+    #[test]
+    fn test_theme_helper_styles() {
+        let theme = Theme::dark();
+
+        assert_eq!(theme.primary_style().fg, Some(Color::Blue));
+        assert_eq!(theme.secondary_style().fg, Some(Color::Cyan));
+        assert_eq!(theme.accent_style().fg, Some(Color::Magenta));
+        assert_eq!(theme.error_style().fg, Some(Color::Red));
+        assert_eq!(theme.warning_style().fg, Some(Color::Yellow));
+        assert_eq!(theme.success_style().fg, Some(Color::Green));
+    }
+
+    #[test]
+    fn test_theme_default() {
+        let theme = Theme::default();
+        assert_eq!(theme.name, "Dark");
+    }
+
+    #[test]
+    fn test_color_palette_default() {
+        let palette = ColorPalette::default();
+        assert_eq!(palette.background, Color::Black);
+        assert_eq!(palette.foreground, Color::White);
+    }
+
+    #[test]
+    fn test_default_styles_generated() {
+        let theme = Theme::dark();
+
+        // Verify that default styles are created
+        assert!(theme.styles.contains_key("base"));
+        assert!(theme.styles.contains_key("title"));
+        assert!(theme.styles.contains_key("border"));
+        assert!(theme.styles.contains_key("selected"));
+        assert!(theme.styles.contains_key("error"));
+        assert!(theme.styles.contains_key("warning"));
+        assert!(theme.styles.contains_key("success"));
+        assert!(theme.styles.contains_key("gauge_bar"));
+        assert!(theme.styles.contains_key("table_header"));
+        assert!(theme.styles.contains_key("list_selected"));
+        assert!(theme.styles.contains_key("tab_active"));
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn test_theme_toml_serialization() {
+        let theme = Theme::dark();
+        let toml_str = theme.to_toml().unwrap();
+
+        // Verify TOML contains expected fields
+        assert!(toml_str.contains("name"));
+        assert!(toml_str.contains("[colors]"));
+        assert!(toml_str.contains("background"));
+        assert!(toml_str.contains("foreground"));
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn test_theme_toml_roundtrip() {
+        let original = Theme::dark();
+        let toml_str = original.to_toml().unwrap();
+        let parsed = Theme::from_toml(&toml_str).unwrap();
+
+        assert_eq!(original.name, parsed.name);
+        assert_eq!(original.colors, parsed.colors);
+    }
+
+    #[test]
+    #[cfg(feature = "serde")]
+    fn test_theme_from_toml() {
+        let toml_str = r#"
+            name = "Test Theme"
+
+            [colors]
+            background = "Black"
+            foreground = "White"
+            primary = "Blue"
+            secondary = "Cyan"
+            accent = "Magenta"
+            error = "Red"
+            warning = "Yellow"
+            success = "Green"
+        "#;
+
+        let theme = Theme::from_toml(toml_str).unwrap();
+        assert_eq!(theme.name, "Test Theme");
+        assert_eq!(theme.colors.background, Color::Black);
+        assert_eq!(theme.colors.foreground, Color::White);
+        assert_eq!(theme.colors.primary, Color::Blue);
+    }
+}

--- a/crates/fusabi-tui-widgets/examples/theme_demo.rs
+++ b/crates/fusabi-tui-widgets/examples/theme_demo.rs
@@ -1,0 +1,99 @@
+//! Demonstration of the theme system with runtime switching.
+//!
+//! This example shows how to use themes with widgets and switch between
+//! different themes at runtime.
+
+use fusabi_tui_core::{
+    buffer::Buffer,
+    layout::Rect,
+    theme::{ColorPalette, Theme},
+    style::Color,
+};
+use fusabi_tui_widgets::{
+    block::Block,
+    borders::{BorderType, Borders},
+    widget::Widget,
+};
+
+fn main() {
+    println!("=== Theme System Demo ===\n");
+
+    // Create buffer for rendering
+    let area = Rect::new(0, 0, 60, 20);
+    let mut buffer = Buffer::new(area);
+
+    // Demo 1: Dark theme
+    println!("Dark Theme:");
+    print_theme_demo(&Theme::dark(), &mut buffer);
+
+    // Demo 2: Light theme
+    println!("\nLight Theme:");
+    print_theme_demo(&Theme::light(), &mut buffer);
+
+    // Demo 3: Slime theme
+    println!("\nSlime Theme:");
+    print_theme_demo(&Theme::slime(), &mut buffer);
+
+    // Demo 4: Custom theme
+    println!("\nCustom Theme:");
+    let custom_palette = ColorPalette {
+        background: Color::Rgb(40, 40, 40),
+        foreground: Color::Rgb(220, 220, 220),
+        primary: Color::Rgb(255, 100, 100),
+        secondary: Color::Rgb(100, 255, 100),
+        accent: Color::Rgb(100, 100, 255),
+        error: Color::Red,
+        warning: Color::Yellow,
+        success: Color::Green,
+    };
+    let custom_theme = Theme::new("Custom", custom_palette);
+    print_theme_demo(&custom_theme, &mut buffer);
+
+    // Demo 5: Theme serialization
+    println!("\n=== Theme Serialization ===");
+    #[cfg(feature = "fusabi-tui-core/serde")]
+    {
+        let theme = Theme::slime();
+        match theme.to_toml() {
+            Ok(toml) => {
+                println!("Slime theme as TOML:\n{}", toml);
+            }
+            Err(e) => println!("Error serializing theme: {}", e),
+        }
+    }
+
+    #[cfg(not(feature = "fusabi-tui-core/serde"))]
+    {
+        println!("(serde feature not enabled)");
+    }
+}
+
+fn print_theme_demo(theme: &Theme, buffer: &mut Buffer) {
+    println!("  Theme: {}", theme.name);
+    println!("  Colors:");
+    println!("    Background: {:?}", theme.colors.background);
+    println!("    Foreground: {:?}", theme.colors.foreground);
+    println!("    Primary:    {:?}", theme.colors.primary);
+    println!("    Secondary:  {:?}", theme.colors.secondary);
+    println!("    Accent:     {:?}", theme.colors.accent);
+    println!("    Error:      {:?}", theme.colors.error);
+    println!("    Warning:    {:?}", theme.colors.warning);
+    println!("    Success:    {:?}", theme.colors.success);
+
+    // Render a themed block
+    let area = Rect::new(0, 0, 50, 10);
+    buffer.clear();
+
+    let block = Block::default()
+        .title(format!("{} Theme Demo", theme.name))
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .themed(theme);
+
+    block.render(area, buffer);
+
+    println!("\n  Themed Block Created:");
+    println!("    Title style:  {:?}", theme.get_style("title"));
+    println!("    Border style: {:?}", theme.get_style("border"));
+    println!("    Base style:   {:?}", theme.base_style());
+}

--- a/crates/fusabi-tui-widgets/src/block.rs
+++ b/crates/fusabi-tui-widgets/src/block.rs
@@ -266,6 +266,33 @@ impl Block {
         self
     }
 
+    /// Applies theme styles to the block.
+    ///
+    /// This method uses the theme's "border" and "title" styles to automatically
+    /// style the block's borders and title text.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use fusabi_tui_core::theme::Theme;
+    /// use fusabi_tui_widgets::block::Block;
+    /// use fusabi_tui_widgets::borders::Borders;
+    ///
+    /// let theme = Theme::dark();
+    /// let block = Block::default()
+    ///     .title("Themed Panel")
+    ///     .borders(Borders::ALL)
+    ///     .themed(&theme);
+    /// ```
+    pub fn themed(mut self, theme: &fusabi_tui_core::Theme) -> Self {
+        self.border_style = theme.get_style("border");
+        self.style = theme.base_style();
+        if let Some(ref mut title) = self.title {
+            title.style = theme.get_style("title");
+        }
+        self
+    }
+
     /// Computes the inner area after accounting for borders and padding.
     ///
     /// This is the area where child widgets should be rendered.


### PR DESCRIPTION
## Summary

Implements a comprehensive theme system for fusabi-tui-runtime that allows for consistent styling across all TUI widgets and components.

### Features Implemented

- **Theme Module** in `fusabi-tui-core` with:
  - `ColorPalette`: Defines base colors (background, foreground, primary, secondary, accent, error, warning, success)
  - `StyleMap`: Maps semantic names to styles for different UI elements
  - `Theme`: Combines palette, styles, and metadata into a complete theme

- **Built-in Themes**:
  - **Dark**: Classic dark theme with standard colors
  - **Light**: Light theme suitable for bright environments  
  - **Slime**: Theme matching Scarab terminal with green/cyan accents (RGB colors from Scarab's slime-theme.toml)

- **TOML Support** (optional `serde` feature):
  - Load themes from TOML files
  - Save themes to TOML files
  - Automatic generation of default styles when loading from TOML

- **Widget Integration**:
  - `Block` widget now has `.themed()` method to apply theme styles
  - Easy to extend to other widgets

- **Style Mappings**:
  - 15+ predefined style names (title, border, selected, error, warning, success, etc.)
  - Custom style mappings supported
  - Helper methods for common styles

### Changes

**Files Added:**
- `crates/fusabi-tui-core/src/theme.rs` (562 lines) - Complete theme implementation
- `crates/fusabi-tui-widgets/examples/theme_demo.rs` - Example demonstrating theme usage
- `THEME_SYSTEM.md` - Comprehensive documentation

**Files Modified:**
- `crates/fusabi-tui-core/Cargo.toml` - Added optional serde dependencies
- `crates/fusabi-tui-core/src/lib.rs` - Exported theme module
- `crates/fusabi-tui-core/src/style.rs` - Added serde derives to Color, Modifier, and Style
- `crates/fusabi-tui-widgets/src/block.rs` - Added `.themed()` method

### Test Plan

- [x] All existing tests pass
- [x] Added comprehensive unit tests for theme module (15+ tests)
- [x] Tests pass with and without `serde` feature
- [x] Example runs successfully and demonstrates all themes
- [x] Documentation is complete and accurate

### Usage Example

```rust
use fusabi_tui_core::theme::Theme;
use fusabi_tui_widgets::{block::Block, borders::Borders};

// Use built-in theme
let theme = Theme::slime();

// Apply theme to widget
let block = Block::default()
    .title("Themed Panel")
    .borders(Borders::ALL)
    .themed(&theme);

// Load custom theme from TOML
let theme = Theme::from_toml_file("my-theme.toml")?;
```

### Slime Theme Details

The Slime theme uses the exact RGB colors from Scarab terminal:
- Background: `#1e2324` (30, 35, 36)
- Foreground: `#e0e0e0` (224, 224, 224)
- Primary: `#a8df5a` (168, 223, 90) - Slime green
- Secondary: `#80B5B3` (128, 181, 179) - Cyan
- Accent: `#AEC199` (174, 193, 153) - Muted green
- Error: `#cd6564` (205, 101, 100) - Red
- Warning: `#fff099` (255, 240, 153) - Yellow
- Success: `#AEC199` (174, 193, 153) - Green

### Future Enhancements

Potential future improvements documented in THEME_SYSTEM.md:
- Hot-reloading themes from files
- Theme inheritance
- Per-widget theme overrides
- Additional built-in themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)