### PR TITLE
feat(widgets): Implement Widget trait for List (Closes #15)

### DIFF
--- a/crates/fusabi-tui-widgets/src/list.rs
+++ b/crates/fusabi-tui-widgets/src/list.rs
@@ -260,6 +260,13 @@ impl<'a> List<'a> {
     }
 }
 
+impl Widget for List<'_> {
+    fn render(&self, area: Rect, buf: &mut Buffer) {
+        let mut state = ListState::default();
+        StatefulWidget::render(self, area, buf, &mut state);
+    }
+}
+
 impl StatefulWidget for List<'_> {
     type State = ListState;
 


### PR DESCRIPTION
## Summary
- Implements the `Widget` trait for the `List` widget
- Delegates to `StatefulWidget` with a default `ListState`
- Allows `List` to be used without explicitly managing state

## Changes
- Added `impl Widget for List<'_>` that creates a default `ListState` and calls `StatefulWidget::render`

## Test plan
- [x] Code compiles with `cargo check`
- [x] Implementation follows the same pattern as other widgets
- [x] No breaking changes to existing code

🤖 Generated with [Claude Code](https://claude.com/claude-code)