### PR TITLE
ci: add native aarch64 Linux to CI and release validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, macos-latest]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,21 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  check-aarch64:
+    name: Check on aarch64 Linux
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Build workspace
+        run: cargo build --workspace --lib
+      - name: Test workspace
+        run: cargo test --workspace --lib
+
   publish:
     name: Publish to crates.io
+    needs: check-aarch64
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Motivation

`raibid-harness` (incoming DGX-Spark-native harness for coding agents)
targets `aarch64-unknown-linux-gnu` as its primary triple.
`harness-tui` (optional dashboard) wraps the crates in this workspace.
Today CI runs only on `ubuntu-latest` + `macos-latest` (both x86_64),
and the release workflow publishes straight to crates.io with no
aarch64 guard.

See survey: `/tmp/fusabi-aarch64-survey.md`.

## What changed

**`.github/workflows/ci.yml`**
- Added `ubuntu-24.04-arm` (native aarch64 runner) to the test matrix,
  so every push / PR builds and tests the workspace on aarch64.

**`.github/workflows/release.yml`**
- New `check-aarch64` job that runs `cargo build --workspace --lib`
  and `cargo test --workspace --lib` on `ubuntu-24.04-arm`.
- `publish` now depends on `check-aarch64`, so a broken aarch64 build
  blocks crates.io publication of `fusabi-tui-core`, `-widgets`,
  `-render`, `-engine`, and `-scarab`.

The release workflow triggers on `release: published` rather than tag
push, so this runs on release creation.

## Test plan

- [ ] New `Test (ubuntu-24.04-arm)` CI leg passes on this PR.
- [ ] Manual `workflow_dispatch` with `dry_run=true` exercises the
      `check-aarch64` job and the dep ordering.

## Known gaps

- `crossterm` / `ratatui` are both pure Rust, no native-dep risk
  expected on aarch64.
- MSRV job (`Minimum Rust Version`) is not extended to aarch64 because
  MSRV is a Rust-version concern, not a target concern.

## Status

**Draft** — ready-for-review after a green aarch64 run.