### PR TITLE
Add NOTICES file with Ratatui MIT license attribution

### DIFF
--- a/NOTICES
+++ b/NOTICES
@@ -1,0 +1,39 @@
+NOTICES
+=======
+
+This file lists third-party software that fusabi-tui-runtime incorporates or
+derives from, along with the required copyright and license notices.
+
+
+Ratatui
+-------
+
+fusabi-tui-runtime borrows and adapts core types from Ratatui (notably
+ratatui-core, e.g. the buffer, layout, and style primitives in
+`fusabi-tui-core`). Ratatui is distributed under the MIT license, which
+requires that the following copyright and permission notice be included.
+
+Source: https://github.com/ratatui/ratatui
+
+The MIT License (MIT)
+
+Copyright (c) 2016-2022 Florian Dehau
+Copyright (c) 2023-2025 The Ratatui Developers
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -372,6 +372,12 @@ Licensed under either of:
 
 at your option.
 
+### Third-Party Notices
+
+This project adapts core types from [Ratatui](https://github.com/ratatui/ratatui)
+(MIT licensed). See [NOTICES](NOTICES) for the required copyright and license
+acknowledgements.
+
 ## Contributing
 
 Contributions are welcome! This project is in active development. Please check the [documentation](docs/) for architecture details before submitting PRs.


### PR DESCRIPTION
## What

Adds a `NOTICES` file at the repository root containing Ratatui's MIT license text and copyright acknowledgement, and references it from the README License section.

## Why

`fusabi-tui-core` adapts ~2K LOC of core primitives from `ratatui-core` (buffer, layout, style types), as documented in `MIGRATION.md` and `CHANGELOG.md`. Ratatui is distributed under the MIT license, which requires that its copyright and permission notice be included in distributions. Issue #21 (from a Ratatui maintainer) requests exactly this compliance.

## Changes

- **`NOTICES`** (new): canonical Ratatui MIT license text fetched verbatim from https://github.com/ratatui/ratatui (Copyright 2016-2022 Florian Dehau; 2023-2025 The Ratatui Developers), with an attribution section noting what fusabi-tui-runtime borrows.
- **`README.md`**: added a "Third-Party Notices" subsection under License pointing to `NOTICES`.

## Verification

Docs-only change; confirmed the workspace still builds and all tests pass.

- `cargo build --workspace` → Finished, exit 0 (warnings only, pre-existing).
- `cargo test --workspace` → 337 passed, 0 failed (1 ignored), exit 0.

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)